### PR TITLE
Rename :return_to param to :origin

### DIFF
--- a/lib/janrain/authentication.rb
+++ b/lib/janrain/authentication.rb
@@ -34,8 +34,8 @@ module Janrain::Authentication
   end
 
   def original_or_default_url(default)
-    url = (session[:return_to] || params[:return_to] || default)
-    session[:return_to] = nil
+    url = (session[:origin] || params[:origin] || default)
+    session[:origin] = nil
     url
   end
 
@@ -61,7 +61,7 @@ module Janrain::Authentication
   end
 
   def access_denied
-    session[:return_to] = request.url
+    session[:origin] = request.url
     redirect_to send("new_janrain_#{Janrain::Config.controller.to_s.downcase}_url"), flash: { error: 'The page you requested requires you to be signed in' }
   end
 

--- a/lib/janrain/config.rb
+++ b/lib/janrain/config.rb
@@ -27,9 +27,9 @@ class Janrain::Config
     if host = options.delete(:host)
       uri.host = host.split(':').first
     end
-    if return_to = options.delete(:return_to)
+    if origin = options.delete(:origin)
       delim = uri.query.blank? ? '' : '&'
-      uri.query = "#{uri.query}#{delim}return_to=#{CGI.escape(return_to)}"
+      uri.query = "#{uri.query}#{delim}origin=#{CGI.escape(origin)}"
     end
     uri.to_s
   end

--- a/spec/lib/janrain/authentication_spec.rb
+++ b/spec/lib/janrain/authentication_spec.rb
@@ -35,7 +35,7 @@ shared_examples "a non admin user" do
   it "should not be allowed" do
     get :admin_login_required
     flash[:error].should_not be_blank
-    controller.session[:return_to].should == 'http://test.host/foobars/admin_login_required'
+    controller.session[:origin].should == 'http://test.host/foobars/admin_login_required'
     response.should redirect_to new_janrain_session_url
   end
 end
@@ -52,7 +52,7 @@ shared_examples "a non super user" do
   it "should not be allowed" do
     get :super_login_required
     flash[:error].should_not be_blank
-    controller.session[:return_to].should == 'http://test.host/foobars/super_login_required'
+    controller.session[:origin].should == 'http://test.host/foobars/super_login_required'
     response.should redirect_to new_janrain_session_url
   end
 end
@@ -69,7 +69,7 @@ shared_examples "an expected to be logged in user" do
   it "should not be allowed" do
     get :reqular_login_required
     flash[:error].should_not be_blank
-    controller.session[:return_to].should == 'http://test.host/foobars/reqular_login_required'
+    controller.session[:origin].should == 'http://test.host/foobars/reqular_login_required'
     response.should redirect_to new_janrain_session_url
   end
 end

--- a/spec/lib/janrain/config_spec.rb
+++ b/spec/lib/janrain/config_spec.rb
@@ -42,8 +42,8 @@ describe Janrain::Config do
         Config.redirect_url(host:'www.other.host.com').should include '://www.other.host.com'
       end
 
-      it "should have redirect url that takes a return_to parameter as an option" do
-        Config.redirect_url(return_to:'http://www.other.host.com/?a=1#b=2').should include 'http://mysite.com/auth?return_to=http%3A%2F%2Fwww.other.host.com%2F%3Fa%3D1%23b%3D2'
+      it "should have redirect url that takes a origin parameter as an option" do
+        Config.redirect_url(origin:'http://www.other.host.com/?a=1#b=2').should include 'http://mysite.com/auth?origin=http%3A%2F%2Fwww.other.host.com%2F%3Fa%3D1%23b%3D2'
       end
     end
 

--- a/spec/lib/janrain/session_spec.rb
+++ b/spec/lib/janrain/session_spec.rb
@@ -25,14 +25,14 @@ describe SessionController, type: :controller do
         response.should redirect_to root_url
       end
 
-      it "should redirct to the return_to url passed in" do
-        get :create, code: 'a_valid_code', return_to: 'http://localhost/yoyo.htm'
+      it "should redirct to the origin url passed in" do
+        get :create, code: 'a_valid_code', origin: 'http://localhost/yoyo.htm'
         response.should redirect_to 'http://localhost/yoyo.htm'
       end
     end
 
     it "should render javascript redirect if configured in modal" do
-      get :create, code: 'a_valid_code', return_to: 'http://localhost/yoyo.htm'
+      get :create, code: 'a_valid_code', origin: 'http://localhost/yoyo.htm'
       response.body.should include("parent.location = 'http://localhost/yoyo.htm'")
     end
   end
@@ -58,7 +58,7 @@ describe SessionController, type: :controller do
     end
 
     it "should sign the user out and redirect to return to url" do
-      get :destroy, return_to: 'http://localhost/yoyo.htm'
+      get :destroy, origin: 'http://localhost/yoyo.htm'
       controller.should_not be_user_signed_in
       response.should redirect_to 'http://localhost/yoyo.htm'
     end


### PR DESCRIPTION
The :redirect_uri parameter that can be passed when generating an oauth token done  in `Janrain::Capture::Client::Oauth` 

When using Federate SSO the redirect url is specified, but origin parameter automatically appended to so it looks something like this `rr.com/session/signin?origin=rr.com`

Before I changed the return_to parameter to origin, when requesting an oauth token using the :code parameter generated by Federate SSO this was failing because it was being passed `rr.com/session/signin?return_to=rr.com` but expecting `rr.com/session/signin?origin=rr.com`

The only functional change was in
lib/janrain/config.rb

``` ruby
uri.query = "#{uri.query}#{delim}return_to=#{CGI.escape(return_to)}"
# to
uri.query = "#{uri.query}#{delim}origin=#{CGI.escape(origin)}"
```

other changes were made for consistency
